### PR TITLE
Update data.csv (Sanda Dia)

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -9,7 +9,7 @@ date,compensation,victim_gender,victim_age,victim_ethnicity,victim_job,source
 21-6-2017,46000,M,37,B,Leerkracht,https://www.hln.be/binnenland/3-jaar-cel-en-bijna-300-000-euro-schadevergoeding-voor-prostituee-die-leraar-afperste-tot-de-dood~a39fe9e3/
 18-4-2018,150000,M,35,B,Kasteelheer,https://www.hln.be/binnenland/familie-van-vermoorde-stijn-saelens-tevreden-met-uitspraak-in-zaak-over-kasteelmoord~af372190/
 5-4-2023,38000,M,21,B,Lasser,https://www.crimilex.be/pers/artikelen.php?id=drugsleverancier-veroordeeld-voor-dood-van-sven-21-gevolgen-zijn-onomkeerbaar
-26-5-2023,23000,M,20,NB,Student,https://www.hln.be/binnenland/overzicht-welke-straffen-hebben-de-reuzegommers-gekregen-voor-de-fatale-doop-van-sanda-dia~af5fcb0d/
+26-5-2023,714276,M,20,NB,Student,https://www.vrt.be/content/dam/vrtnieuws/bestanden/hof-van-beroep-antwerpen-uitspraak-in-de-zaak-reuzegom.pdf
 21-1-2023,40000,M,21,B,Student,https://www.nieuwsblad.be/cnt/dmf20230121_94309544
 12-3-2019,9500,V,71,B,Gepensioneerd,https://www.nieuwsblad.be/cnt/dmf20190311_04246115
 13-9-2014,20101,V,21,B,Student,https://www.hln.be/lokeren/milde-eindrekening-voor-doodrijder-20-101-euro-schadevergoeding-voor-nabestaanden-iris-aper~a3a23cff/


### PR DESCRIPTION
Zie het arrest vanaf p114 punt "6.2. Rechtdoende op burgerlijk gebied". Ik heb alle toegekende schadevergoedingen opgeteld voor alle burgelijke partijen VD, JD, BPL, CM, FM, KP, OD, MM, SDV, MVS en ADV (waaronder de vrienden die slechts 1 EUR symbolische schadevergoeding toegewezen kregen), die hoofdelijk (dus per beklaagde) dienen betaald te worden, vermenigvuldigd met het aantal beklaagden, zijnde 18 (AV, LL, AGG, JJ, AG, BP, VK, ZB, JS, MP, MG, WP, SP, PO, JV, QW, JDV en BL).